### PR TITLE
Case and Intrinsic Lifting/Unlifting

### DIFF
--- a/compiler/bin/a_builtins.ml
+++ b/compiler/bin/a_builtins.ml
@@ -14,7 +14,7 @@ main:
     
     pushq   %rax
     call    Main.main
-    pop     %rax
+    addq    $8, %rsp
 
     pop     %rbp
     ret
@@ -263,6 +263,62 @@ substr:
     pop     %r12
     ret
 
+    .text
+    .globl  unlift_int
+    .type   unlift_int, @function
+unlift_int:
+    movq    $1, %rdi
+    movq    $32, %rsi
+    call    calloc
+
+    movq    $.objname_Int, (%rax)
+    movq    $32, 8(%rax)
+    movq    $.vtable_Int, 16(%rax)
+    movq    16(%rbp), %rdi
+    movq    %rdi, 24(%rax)
+
+    ret
+
+    .text
+    .globl  unlift_int
+    .type   unlift_int, @function
+unlift_string:
+    movq    $1, %rdi
+    movq    $32, %rsi
+    call    calloc
+
+    movq    $.objname_String, (%rax)
+    movq    $32, 8(%rax)
+    movq    $.vtable_String, 16(%rax)
+    movq    16(%rbp), %rdi
+    movq    %rdi, 24(%rax)
+
+    ret
+
+    .text
+    .globl  unlift_int
+    .type   unlift_int, @function
+unlift_bool:
+    movq    $1, %rdi
+    movq    $32, %rsi
+    call    calloc
+
+    movq    $.objname_Bool, (%rax)
+    movq    $32, 8(%rax)
+    movq    $.vtable_Bool, 16(%rax)
+    movq    16(%rbp), %rdi
+    movq    %rdi, 24(%rax)
+
+    ret
+
+    .text
+    .globl  lift_int
+    .type   lift_int, @function
+lift_int:
+    movq    16(%rbp), %rax
+    movq    24(%rax), %rax
+    ret
+
     .section .rodata
 default_string:
     .string ""
@@ -298,6 +354,8 @@ error_dispatch:
     movq    $error_dispatch_msg, %rdi
     xorq    %rax, %rax
     callq   printf
+
+    int3
 
     movq    $1, %rdi
     callq   exit

--- a/compiler/bin/a_builtins.ml
+++ b/compiler/bin/a_builtins.ml
@@ -314,7 +314,8 @@ unlift_bool:
     .text
     .globl  lift_int
     .type   lift_int, @function
-lift_int:
+
+lift_val:
     movq    16(%rbp), %rax
     movq    24(%rax), %rax
     ret

--- a/compiler/bin/a_builtins.ml
+++ b/compiler/bin/a_builtins.ml
@@ -332,6 +332,12 @@ error_divide_msg:
 error_dispatch_msg:
     .string "ERROR: %d: Exception: dispatch on void\n"
     .align 8
+error_case_msg:
+    .string "ERROR: %d: Exception: case on void\n"
+    .align 8
+error_case_unmatched_msg:
+    .string "ERROR: %d: Exception: no valid case for expression\n"
+    .align 8
 error_substring_msg:
     .string "ERROR: 0: Exception: String.substr out of range\n"
     .align 8
@@ -356,11 +362,37 @@ error_dispatch:
     xorq    %rax, %rax
     callq   printf
 
-    int3
+    movq    $1, %rdi
+    callq   exit
+    ret
+
+    .text
+    .globl error_case_void
+    .type  error_case_void, @function
+error_case_void:
+    movq    $error_case_msg, %rdi
+    xorq    %rax, %rax
+    callq   printf
 
     movq    $1, %rdi
     callq   exit
     ret
+
+    .text
+    .globl error_case_unmatched
+    .type  error_case_unmatched, @function
+error_case_unmatched:
+    movq    $error_case_unmatched_msg, %rdi
+    xorq    %rax, %rax
+    callq   printf
+
+    movq    $1, %rdi
+    callq   exit
+    ret
+
+    .text
+    .globl error_substr
+    .type  error_substr, @function
 error_substr:
     movq    $error_substring_msg, %rdi
     xorq    %rax, %rax

--- a/compiler/bin/b_parent_map.ml
+++ b/compiler/bin/b_parent_map.ml
@@ -1,16 +1,14 @@
 open A_parser
+open A_util
 
-type parent_relation = {
-    parent: string;
-    child: string;
-}
+type parent_map = string StringMap.t
 
-let parse_parent_map (data : parser_data) : (parser_data * parent_relation list) =
-    let parse_parent_relation (data : parser_data) : (parser_data * parent_relation) =
+let parse_parent_map (data : parser_data) : (parser_data * parent_map) =
+    let parse_parent_relation (data : parser_data) : (parser_data * (string * string)) =
         let data, parent = parse_line data in
         let data, child = parse_line data in
 
-        data, { parent = parent; child = child; }
+        data, (parent, child)
     in
 
     let data, first_line = parse_line data in
@@ -19,4 +17,5 @@ let parse_parent_map (data : parser_data) : (parser_data * parent_relation list)
         raise (Invalid_argument ("Expected parent_map, got " ^ first_line))
     ;
 
-    parse_list data parse_parent_relation
+    let data, relations = parse_list data parse_parent_relation in
+    data, StringMap.of_seq (List.to_seq relations)

--- a/compiler/bin/c_parser_data.ml
+++ b/compiler/bin/c_parser_data.ml
@@ -5,10 +5,10 @@ open B_impl_map
 open B_parent_map
 
 type parsed_data = {
-    ast     : ast_class list;
-    class_map : class_data list;
-    impl_map : impl_class list;
-    parent_map : parent_relation list;
+    ast         : ast_class list;
+    class_map   : class_data list;
+    impl_map    : impl_class list;
+    parent_map  : parent_map;
 }
 
 type program_class_data = {
@@ -21,19 +21,12 @@ type program_class_data = {
 type program_data = {
     ast         : ast_class list;
 
+    parent_map  : parent_map;
     data_map    : program_class_data StringMap.t;
     overriden_classes : StringSet.t;
 }
 
 let organize_parser_data (parsed_data : parsed_data) : program_data =
-    let rec aggregate_overrides (parent_relation : parent_relation list) (acc : StringSet.t) : StringSet.t =
-        match parent_relation with
-        | [] -> acc
-        | { child; parent } :: rest ->
-            let new_acc = StringSet.add child acc in
-            aggregate_overrides rest new_acc
-    in
-
     let rec internal_rec (class_data : class_data list) (impl_class : impl_class list) : program_class_data list =
         match class_data, impl_class with
         | [], [] -> []
@@ -42,17 +35,57 @@ let organize_parser_data (parsed_data : parsed_data) : program_data =
         | _, _ -> raise (Invalid_argument "This shouldnt happen!")
     in
 
-    let overriden_classes = aggregate_overrides parsed_data.parent_map StringSet.empty in
+    let overriden_classes = StringMap.fold (
+        fun child parent acc -> StringSet.add parent acc
+    ) parsed_data.parent_map StringSet.empty in
 
     let pcd_list = internal_rec parsed_data.class_map parsed_data.impl_map in
     let pcd_map = List.fold_left (
         fun acc pcd -> StringMap.add pcd.name pcd acc 
     ) StringMap.empty pcd_list in
 
-    { ast = parsed_data.ast; data_map = pcd_map; overriden_classes = overriden_classes }
+    { 
+        ast = parsed_data.ast; 
+        data_map = pcd_map; 
+        overriden_classes = overriden_classes;
+        parent_map = parsed_data.parent_map;
+    }
 
 let get_dispatch (data : program_data) (class_name : string) (method_name : string) : int =
     let class_data = StringMap.find class_name data.data_map in
     let method_id = find_index class_data.methods (fun impl_method -> impl_method.name = method_name) in
 
     method_id
+
+let parent_of (data : program_data) (class_name : string) : string =
+    match StringMap.find_opt class_name data.parent_map with
+    | Some parent -> parent
+    | None -> 
+        Printf.printf "Warning: Class %s has no parent.\n" class_name;
+        StringMap.iter (fun k v -> Printf.printf "Class: %s, Parent: %s\n" k v) data.parent_map;
+        exit 0
+
+let get_method_signature (data : program_data) (class_name : string) (method_name : string) : string * (string * string) list =
+    let rec recursive_routine (class_name : string) (method_name : string) =
+        let class_data = List.find (fun (class_data : ast_class) -> class_data.name.name = class_name) data.ast in
+        
+        let _method = List.find_opt (
+            fun (method_data : ast_method) -> method_data.name.name = method_name
+        ) class_data.methods in
+
+        match _method with
+        | Some method_data -> 
+            method_data._type.name, List.map (fun (param : ast_param) -> param.name.name, param._type.name) method_data.params
+        | None ->
+
+            if class_name = "Object" then
+                raise (Invalid_argument ("Method not found: " ^ method_name))
+            else
+                let parent = parent_of data class_name in
+                recursive_routine parent method_name
+    in
+    
+    let return_type, params = recursive_routine class_name method_name in
+    let return_type = if return_type = "SELF_TYPE" then class_name else return_type in
+
+    return_type, params

--- a/compiler/bin/d_tac_data.ml
+++ b/compiler/bin/d_tac_data.ml
@@ -11,7 +11,7 @@ module StringTbl = Hashtbl.Make (struct
     let hash = Hashtbl.hash
 end)
 
-type symbol_table = tac_id StringTbl.t
+type symbol_table = (tac_id * string) StringTbl.t
 
 type tac_cmd =
   | TAC_add     of tac_id * tac_id * tac_id
@@ -46,11 +46,14 @@ type tac_cmd =
 
   | TAC_internal of string
 
+  | TAC_return  of tac_id
+  | TAC_comment of string
+
   (* Special Internal Nodes *)
   | TAC_str_eq  of tac_id * tac_id * tac_id
 
-  | TAC_return  of tac_id
-  | TAC_comment of string
+  (* Since this has to cache the line number, it is a separate node, at least for now *)
+  | TAC_void_check of int * tac_id
 
 type method_tac = {
     class_name: string;

--- a/compiler/bin/d_tac_data.ml
+++ b/compiler/bin/d_tac_data.ml
@@ -53,7 +53,8 @@ type tac_cmd =
   | TAC_str_eq  of tac_id * tac_id * tac_id
 
   (* Since this has to cache the line number, it is a separate node, at least for now *)
-  | TAC_void_check of int * tac_id
+  | TAC_void_check of int * tac_id * string
+  | TAC_inline_assembly of string
 
 type method_tac = {
     class_name: string;

--- a/compiler/bin/f_tac_gen.ml
+++ b/compiler/bin/f_tac_gen.ml
@@ -87,7 +87,7 @@ let generate_tac (data : program_data) : method_tac list =
             List.iteri (
                 fun i (name, _type) ->
                     StringTbl.add !symbol_table name (Parameter i, _type)
-            ) params;
+            ) @@ List.combine method_.formals params;
 
             let body = tac_gen_expr_body data _class.name return_type method_.body symbol_table temp_counter local_counter in
 

--- a/compiler/bin/f_tac_gen.ml
+++ b/compiler/bin/f_tac_gen.ml
@@ -6,7 +6,7 @@ open C_parser_data
 open D_tac_data
 open E_tac_expr_gen
 
-let generate_constructor (data : program_data) (_class : program_class_data) : method_tac =
+let generate_constructor (data : program_data) (symbol_table : symbol_table ref) (_class : program_class_data) : method_tac =
     let temp_counter = ref 0 in
     let local_counter = ref 0 in
 
@@ -14,7 +14,7 @@ let generate_constructor (data : program_data) (_class : program_class_data) : m
     let object_id = Local 0 in
     let ids = ref [ object_id ] in
 
-    let instantiate = TAC_object ( object_id , _class.name, attributes) in
+    let instantiate = TAC_object ( object_id, _class.name, attributes) in
     let return = TAC_return object_id in
     
     (* TODO: Attribute initialization *)
@@ -38,7 +38,7 @@ let generate_constructor (data : program_data) (_class : program_class_data) : m
                     TAC_attribute { object_id; attribute_id; value = id }
                 ]
             | Some init ->
-                let (tac_ids, tac_cmds) = tac_gen_expr_body data _class.name init (ref (StringTbl.create 10)) local_counter temp_counter in
+                let (tac_ids, tac_cmds) = tac_gen_expr_body data _class.name init symbol_table local_counter temp_counter in
                 let ret = last_id tac_ids in
                 
                 ids := !ids @ tac_ids;
@@ -60,13 +60,15 @@ let generate_constructor (data : program_data) (_class : program_class_data) : m
 let generate_tac (data : program_data) : method_tac list =
     let symbol_table : symbol_table ref = ref @@ StringTbl.create 10 in
 
-    StringTbl.add !symbol_table "self" Self;
-
     let tac_class_impl (_class : program_class_data) : method_tac list =
+        StringTbl.add !symbol_table "self" (Self, _class.name);
+
         List.iteri (
             fun i (attr : attribute_data) ->
-                StringTbl.add !symbol_table attr.name (Attribute i)
+                StringTbl.add !symbol_table attr.name (Attribute i, "")
         ) _class.attributes;
+
+        let constructor = generate_constructor data symbol_table _class in
 
         let tac_ast_method (method_ : impl_method) : (tac_id list * tac_cmd list) =
             let _method = List.find (
@@ -81,8 +83,9 @@ let generate_tac (data : program_data) : method_tac list =
             | _ ->
 
             List.iteri (
+                (* TODO: Retrieve type of parameter *)
                 fun i formal ->
-                    StringTbl.add !symbol_table formal (Parameter i)
+                    StringTbl.add !symbol_table formal (Parameter i, "")
             ) method_.formals;
 
             let cmds = tac_gen_expr_body data _class.name method_.body symbol_table temp_counter local_counter in
@@ -109,11 +112,13 @@ let generate_tac (data : program_data) : method_tac list =
         ) _class.methods in
 
         List.iter (
-            fun (method_ : impl_method) ->
-                StringTbl.remove !symbol_table method_.name
-        ) _class.methods;
+            fun (attribute : attribute_data) ->
+                StringTbl.remove !symbol_table attribute.name
+        ) _class.attributes;
 
-        generate_constructor data _class :: methods
+        StringTbl.remove !symbol_table "self";
+
+        constructor :: methods
     in
 
     StringMap.fold (

--- a/compiler/bin/h_asm_data.ml
+++ b/compiler/bin/h_asm_data.ml
@@ -56,10 +56,11 @@ type asm_cmd =
     | COMMENT   of string
 
 type asm_method = {
-    header: string;
-    arg_count: int;
+    class_name  : string;
+    header      : string;
+    arg_count   : int;
 
-    commands: asm_cmd list;
+    commands    : asm_cmd list;
     string_literals: (string * string) list;
 }
 

--- a/compiler/bin/h_asm_data.ml
+++ b/compiler/bin/h_asm_data.ml
@@ -35,6 +35,8 @@ type asm_cmd =
     | SETLE
     | SETE
 
+    | SETNE
+
 
     | PUSH      of asm_reg
     | POP       of asm_reg
@@ -150,6 +152,7 @@ let print_asm_cmd (output : string -> unit) (arg_count : int) (cmd : asm_cmd) : 
     | SETL   -> format_cmd1 "setl" "%al"
     | SETLE  -> format_cmd1 "setle" "%al"
     | SETE   -> format_cmd1 "sete" "%al"
+    | SETNE  -> format_cmd1 "setne" "%al"
 
     | PUSH reg       -> format_cmd1 "pushq" (asm_reg_to_string reg)
     | POP reg        -> format_cmd1 "popq" (asm_reg_to_string reg)

--- a/compiler/bin/main.ml
+++ b/compiler/bin/main.ml
@@ -39,6 +39,7 @@ let () =
     let parsed_data : parsed_data = { 
         ast = ast; class_map = class_map; impl_map = impl_map; parent_map = parent_map; 
     } in
+
     let program_data = organize_parser_data parsed_data in
     let method_tacs = generate_tac program_data in
 (* 

--- a/compiler/builtins.s
+++ b/compiler/builtins.s
@@ -14,7 +14,7 @@ main:
     
     pushq   %rax
     call    Main.main
-    pop     %rax
+    addq    $8, %rsp
 
     pop     %rbp
     ret
@@ -263,6 +263,62 @@ substr:
     pop     %r12
     ret
 
+    .text
+    .globl  unlift_int
+    .type   unlift_int, @function
+unlift_int:
+    movq    $1, %rdi
+    movq    $32, %rsi
+    call    calloc
+
+    movq    $.objname_Int, (%rax)
+    movq    $32, 8(%rax)
+    movq    $.vtable_Int, 16(%rax)
+    movq    16(%rbp), %rdi
+    movq    %rdi, 24(%rax)
+
+    ret
+
+    .text
+    .globl  unlift_int
+    .type   unlift_int, @function
+unlift_string:
+    movq    $1, %rdi
+    movq    $32, %rsi
+    call    calloc
+
+    movq    $.objname_String, (%rax)
+    movq    $32, 8(%rax)
+    movq    $.vtable_String, 16(%rax)
+    movq    16(%rbp), %rdi
+    movq    %rdi, 24(%rax)
+
+    ret
+
+    .text
+    .globl  unlift_int
+    .type   unlift_int, @function
+unlift_bool:
+    movq    $1, %rdi
+    movq    $32, %rsi
+    call    calloc
+
+    movq    $.objname_Bool, (%rax)
+    movq    $32, 8(%rax)
+    movq    $.vtable_Bool, 16(%rax)
+    movq    16(%rbp), %rdi
+    movq    %rdi, 24(%rax)
+
+    ret
+
+    .text
+    .globl  lift_int
+    .type   lift_int, @function
+lift_int:
+    movq    16(%rbp), %rax
+    movq    24(%rax), %rax
+    ret
+
     .section .rodata
 default_string:
     .string ""
@@ -298,6 +354,8 @@ error_dispatch:
     movq    $error_dispatch_msg, %rdi
     xorq    %rax, %rax
     callq   printf
+
+    int3
 
     movq    $1, %rdi
     callq   exit

--- a/compiler/builtins.s
+++ b/compiler/builtins.s
@@ -314,7 +314,8 @@ unlift_bool:
     .text
     .globl  lift_int
     .type   lift_int, @function
-lift_int:
+
+lift_val:
     movq    16(%rbp), %rax
     movq    24(%rax), %rax
     ret

--- a/compiler/builtins.s
+++ b/compiler/builtins.s
@@ -332,6 +332,12 @@ error_divide_msg:
 error_dispatch_msg:
     .string "ERROR: %d: Exception: dispatch on void\n"
     .align 8
+error_case_msg:
+    .string "ERROR: %d: Exception: case on void\n"
+    .align 8
+error_case_unmatched_msg:
+    .string "ERROR: %d: Exception: no valid case for expression\n"
+    .align 8
 error_substring_msg:
     .string "ERROR: 0: Exception: String.substr out of range\n"
     .align 8
@@ -356,11 +362,37 @@ error_dispatch:
     xorq    %rax, %rax
     callq   printf
 
-    int3
+    movq    $1, %rdi
+    callq   exit
+    ret
+
+    .text
+    .globl error_case_void
+    .type  error_case_void, @function
+error_case_void:
+    movq    $error_case_msg, %rdi
+    xorq    %rax, %rax
+    callq   printf
 
     movq    $1, %rdi
     callq   exit
     ret
+
+    .text
+    .globl error_case_unmatched
+    .type  error_case_unmatched, @function
+error_case_unmatched:
+    movq    $error_case_unmatched_msg, %rdi
+    xorq    %rax, %rax
+    callq   printf
+
+    movq    $1, %rdi
+    callq   exit
+    ret
+
+    .text
+    .globl error_substr
+    .type  error_substr, @function
 error_substr:
     movq    $error_substring_msg, %rdi
     xorq    %rax, %rax

--- a/compiler/run-full
+++ b/compiler/run-full
@@ -4,6 +4,13 @@ rm a.out 2> /dev/null
 cool --type "$1.cl"
 
 ./run "$1.cl-type"
+
+if [ "$?" -ne 0 ]; then
+    exit 1
+fi
+
 ./run-compile "$1.s"
 
 ./a.out
+
+exit 0

--- a/compiler/run-test
+++ b/compiler/run-test
@@ -5,8 +5,16 @@ if [ "$#" -gt 1 ]; then
     input=$2
 fi
 
-cool_output=$(cat "test_input" | cool "$1.cl")
 dune_output=$(cat "test_input" | ./run-full "$1")
+
+if [ "$?" -ne 0 ]; then
+    echo "Test failed: $1"
+    echo "Dune output: "
+    echo $dune_output
+    exit 1
+fi
+
+cool_output=$(cat "test_input" | cool "$1.cl")
 
 if [ "$cool_output" != "$dune_output" ]; then
     echo "Test failed: $1"

--- a/compiler/run-tests
+++ b/compiler/run-tests
@@ -29,5 +29,15 @@ for file in valid_testcases/*.cl; do
     run_test $file $input
 done
 
+for file in invalid_testcases/*.cl; do
+    printf "Running test: $file -- "
+    run_test $file $input
+done
+
+for file in large_testcases/*.cl; do
+    printf "Running test: $file -- "
+    run_test $file $input
+done
+
 echo "Success: $success"
 echo "Fail: $fail"

--- a/compiler/run-tests
+++ b/compiler/run-tests
@@ -12,18 +12,20 @@ run_test() {
 
     if [ "$code" -eq "0" ]; then
         success=$((success+1))
-        echo "Test passed for $file"
+        echo "PASSED!"
     else
         fail=$((fail+1))
-        echo "Test failed for $file"
+        echo "FAILED!"
     fi
 }
 
 for file in restricted_testcases/*.cl; do
+    printf "Running test: $file -- "
     run_test $file $input
 done
 
 for file in valid_testcases/*.cl; do
+    printf "Running test: $file -- "
     run_test $file $input
 done
 

--- a/compiler/valid_testcases/intrinsic_case.cl
+++ b/compiler/valid_testcases/intrinsic_case.cl
@@ -1,0 +1,12 @@
+class Main inherits IO {
+    val (obj : Object) : Object {
+        case obj of
+            i : Int => out_string("Success!\n");
+            o : Object => abort();
+        esac
+    };
+
+    main() : Object {
+        val(2)
+    };
+};

--- a/compiler/valid_testcases/param.cl
+++ b/compiler/valid_testcases/param.cl
@@ -1,0 +1,7 @@
+class Main inherits IO {
+    params(parameter_x : Int, parameter_y : Object) : Object { 0 };
+    
+    main() : Object {
+        0    
+    };
+};

--- a/compiler/valid_testcases/simple_case.cl
+++ b/compiler/valid_testcases/simple_case.cl
@@ -1,0 +1,8 @@
+class Main {
+    main() : Object {
+        case self of
+            m : Main => 0;
+            o : Object => abort();
+        esac
+    };
+};

--- a/compiler/valid_testcases/unlift.cl
+++ b/compiler/valid_testcases/unlift.cl
@@ -1,0 +1,22 @@
+class Main inherits IO {
+    main() : Object {
+        let x : Object <- 2 in
+        let y : Object <- false in
+        let z : Object <- "String" in
+
+        let x2 : Object, y2 : Object, z2 : Object in
+        {
+            x2 <- 2;
+            y2 <- false;
+            z2 <- "String";
+
+            out_string(x.type_name());
+            out_string(y.type_name());
+            out_string(z.type_name());
+
+            out_string(x2.type_name());
+            out_string(y2.type_name());
+            out_string(z2.type_name());
+        }
+    };
+};


### PR DESCRIPTION
An incredibly inefficient case statement that seems to work for now. Also a little quirk with the data representation system, since integers, booleans, and strings are simply represented as their intrinsic data type, while you can maneuver dispatch to avoid their lack of vtables, if they are assigned for instance to a variable of type Object, you need to turn them into proper objects with a header and vtable. I am borrowing the terminology from Haskell where these data types are 'lifted', where unlifted data types are stored on the heap with metadata.

Also 55/82.